### PR TITLE
Update link to point to new repository location

### DIFF
--- a/update/index.html
+++ b/update/index.html
@@ -6,7 +6,7 @@
         <h1>Eclipse Color Theme Update Site</h1>
         <p>
 This is an Eclipse update site for
-<a href="http://github.com/fhd/eclipse-color-theme">Eclipse Color Theme</a>.
+<a href="https://github.com/eclipse-color-theme/eclipse-color-theme">Eclipse Color Theme</a>.
 There is no point in opening it in your browser.
         </p>
     </body>


### PR DESCRIPTION
The link in the webpage now points to the eclipse-color-theme user instead of the old fhd user.
